### PR TITLE
Fixed indent error in EigerLive_process.py

### DIFF
--- a/NPC/gui/online/EigerLive_process.py
+++ b/NPC/gui/online/EigerLive_process.py
@@ -140,7 +140,7 @@ def workerEuXFEL(wrk_num, HF):
                 # else:
                 #    nohit_IDX.append(frameID)
 
-    if socks.get(control_receiver) == zmq.POLLIN:
+        if socks.get(control_receiver) == zmq.POLLIN:
             newParams = control_receiver.recv_json(zmq.NOBLOCK)
 
             if newParams.keys()[0] in ["STOP", "resetMP"]:


### PR DESCRIPTION
Hi,

I think this fixes a typo in the process loop of workerEuXFEL() function (could not run it with SOLEIL's PX2 Eiger without the fix). 

Cheers,
Martin